### PR TITLE
Clarify installation instructions for beginners

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -22,6 +22,10 @@ Perl 5.20.0 for scripts ( [x86]({{ site.dl_url }}/misc/perl/Perl%205.20.0%20x86.
 Nearly all distributions have official packages for HexChat. On those which don't, you may use contributed, unofficial packages:
 
 - [PPA for Ubuntu/Mint older than 14.04](https://launchpad.net/~gwendal-lebihan-dev/+archive/hexchat-stable)
+- Debian-based: `sudo apt-get install hexchat`
+- Fedora-based: `sudo yum install hexchat`
+- Arch-based: `sudo pacman install hexchat`
+- SUSE-based: `sudo zypper in hexchat`
 
 ## OS X
 Note that this is the first major release officially supporting OS X so some issues are known to exist.

--- a/downloads.md
+++ b/downloads.md
@@ -24,7 +24,7 @@ Nearly all distributions have official packages for HexChat. On those which don'
 - [PPA for Ubuntu/Mint older than 14.04](https://launchpad.net/~gwendal-lebihan-dev/+archive/hexchat-stable)
 - Debian-based: `sudo apt-get install hexchat`
 - Fedora-based: `sudo yum install hexchat`
-- Arch-based: `sudo pacman install hexchat`
+- Arch-based: `sudo pacman -S hexchat`
 - SUSE-based: `sudo zypper in hexchat`
 
 ## OS X


### PR DESCRIPTION
Not only would this help beginners find their way, it also helps experienced users notice that Hexchat is in official repos. 
When I first tried to install Hexchat on Linux, I didn't realize there was an official package, and compiled Hexchat from source.