### PR TITLE
Adding link to homebrew cask

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -56,6 +56,8 @@ sudo snap install hexchat
 
 You can find builds from third party distributors such as [Homebrew](http://brew.sh/) in the [homebrew-gui](https://github.com/Homebrew/homebrew-gui) repository.
 
+Install with [Homebrew Cask](https://caskroom.github.io/) if you prefer to launch Hexchat from Spotlight or the applications menu.
+
 ## Source
 - [Development Version](https://github.com/hexchat/hexchat/archive/master.tar.gz)
 - [{{ site.version }}]({{ site.dl_url }}/hexchat/hexchat-{{ site.version }}.tar.xz)


### PR DESCRIPTION
Running hexchat on mac without cask is annoying as you must keep a terminal window open for the process & you can't launch from spotlight. :+1: