### PR TITLE
Make Windows 7/8/10 download intuitively accesable

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -3,8 +3,11 @@ layout: default
 title: Downloads
 ---
 
+# Hexchat Downloads
+
 ## Windows 7/8/10
-**HexChat {{ site.version }}** ( [x86]({{ site.dl_url }}/hexchat/HexChat%20{{ site.win_version }}%20x86.exe) / [x64]({{ site.dl_url }}/hexchat/HexChat%20{{ site.win_version }}%20x64.exe) )
+
+HexChat {{ site.version }} ( [x86]({{ site.dl_url }}/hexchat/HexChat%20{{ site.win_version }}%20x86.exe) / [x64]({{ site.dl_url }}/hexchat/HexChat%20{{ site.win_version }}%20x64.exe) )
 
 #### Extra components
 


### PR DESCRIPTION
A friend and I have noticed (or rather, not noticed) the Windows 7/8/10 downloads intuitively, since the title is the first thing and the version name is bold, we just assumed its part of a title (like "Hexchat Downloads"). Now that it can be found and the version name is no longer bold, I hope it is intuitively findable.