### PR TITLE
fix: space out text in navigation bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,9 +40,9 @@
           <li><a href="/downloads.html">Get <strong>Downloads</strong></a></li>
           <li><a href="/themes.html">View <strong>Themes</strong></a></li>
           <li><a href="/news.html">Read <strong>News</strong></a></li>
-          <li><a href="https://github.com/hexchat">SeeOn <strong>GitHub</strong></a></li>
+          <li><a href="https://github.com/hexchat">See on <strong>GitHub</strong></a></li>
           <li><a href="https://tingping.github.io/donate/">Send <strong>Donation</strong></a></li>
-          <li><a href="https://hexchat.readthedocs.org">ReadThe <strong>Docs</strong></a></li>
+          <li><a href="https://hexchat.readthedocs.org">Read the <strong>Docs</strong></a></li>
         </ul>
       </header>
       <section>


### PR DESCRIPTION
This PR adds text spacing to the "See on GitHub" and "Read the Docs" buttons for better readability.